### PR TITLE
Adicionando gerador de sitemap e profiles da HE para busca do google

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,8 +24,10 @@ permalink: /:title/
 
 gems:
   - jekyll-redirect-from
+  - jekyll-sitemap
 
 whitelist:
   - jekyll-redirect-from
+  - jekyll-sitemap
 
 exclude: ['Rakefile', 'README', 'Gemfile', 'Gemfile.lock', 'config.rb', 'vendor', 'node_modules', 'stylesheets/sass', 'images/src']

--- a/_includes/footer-2016-pt.html
+++ b/_includes/footer-2016-pt.html
@@ -26,5 +26,6 @@
 
 </footer>
 {% include scripts.html %}
+{% include google-search-social-profiles.html %}
 </body>
 </html>

--- a/_includes/footer-2016.html
+++ b/_includes/footer-2016.html
@@ -26,5 +26,6 @@
 
 </footer>
 {% include scripts.html %}
+{% include google-search-social-profiles.html %}
 </body>
 </html>

--- a/_includes/google-search-social-profiles.html
+++ b/_includes/google-search-social-profiles.html
@@ -1,0 +1,17 @@
+<script type="application/ld+json">
+  {
+    "@context" : "http://schema.org",
+    "@type" : "Organization",
+    "name" : "HE:labs",
+    "url" : "http://www.helabs.com",
+    "sameAs" : [
+      "http://facebook.com/helabs",
+      "http://twitter.com/helabs",
+      "http://google.com/+HElabs",
+      "http://instagram.com/he.labs/",
+      "http://youtube.com/user/helabsoficial/",
+      "http://linkedin.com/company/helabs",
+      "http://dribbble.com/helabs",
+    ]
+  }
+</script>

--- a/proposta-enviada.html
+++ b/proposta-enviada.html
@@ -1,4 +1,5 @@
 ---
+sitemap: false
 layout: site-2016-pt
 title: Proposta enviada | HE:labs
 description: Proposta enviada

--- a/proposta.html
+++ b/proposta.html
@@ -1,4 +1,5 @@
 ---
+sitemap: false
 layout: site-2016-pt
 title: Proposta | HE:labs
 description: Proposta


### PR DESCRIPTION
- Adicionado gerador de sitemap.

<img width="1280" alt="screen shot 2016-03-18 at 18 39 18" src="https://cloud.githubusercontent.com/assets/27034/13892844/dcb0b01e-ed38-11e5-962a-4f82b93a24c1.png">

- adicionado metadata para configuração das redes sociais da HE:labs para serem exibidas no perfil do google quando uma busca for feita pelo nome da empresa.

```js
<script type="application/ld+json">
  {
    "@context" : "http://schema.org",
    "@type" : "Organization",
    "name" : "HE:labs",
    "url" : "http://www.helabs.com",
    "sameAs" : [
      "http://facebook.com/helabs",
      "http://twitter.com/helabs",
      "http://google.com/+HElabs",
      "http://instagram.com/he.labs/",
      "http://youtube.com/user/helabsoficial/",
      "http://linkedin.com/company/helabs",
      "http://dribbble.com/helabs",
    ]
  }
</script>
``` 